### PR TITLE
fix: patch PostCSS vulnerability

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -5081,34 +5081,6 @@
       "integrity": "sha512-fbb2C7HChgM7CemdCY+y3N1n8pcTKdqtQLbC7/EQtPdLvlMUT9JX/dBYl8MMZAtYG4uVMyPFHXckb68q/NRwqg==",
       "license": "MIT"
     },
-    "node_modules/next/node_modules/postcss": {
-      "version": "8.4.31",
-      "resolved": "https://registry.npmjs.org/postcss/-/postcss-8.4.31.tgz",
-      "integrity": "sha512-PS08Iboia9mts/2ygV3eLpY5ghnUcfLV/EXTOW1E2qYxJKGGBUtNjN76FYHnMs36RmARn41bC0AZmn+rR0OVpQ==",
-      "funding": [
-        {
-          "type": "opencollective",
-          "url": "https://opencollective.com/postcss/"
-        },
-        {
-          "type": "tidelift",
-          "url": "https://tidelift.com/funding/github/npm/postcss"
-        },
-        {
-          "type": "github",
-          "url": "https://github.com/sponsors/ai"
-        }
-      ],
-      "license": "MIT",
-      "dependencies": {
-        "nanoid": "^3.3.6",
-        "picocolors": "^1.0.0",
-        "source-map-js": "^1.0.2"
-      },
-      "engines": {
-        "node": "^10 || ^12 || >=14"
-      }
-    },
     "node_modules/node-forge": {
       "version": "1.4.0",
       "resolved": "https://registry.npmjs.org/node-forge/-/node-forge-1.4.0.tgz",
@@ -5378,10 +5350,9 @@
       }
     },
     "node_modules/postcss": {
-      "version": "8.5.6",
-      "resolved": "https://registry.npmjs.org/postcss/-/postcss-8.5.6.tgz",
-      "integrity": "sha512-3Ybi1tAuwAP9s0r1UQ2J4n5Y0G05bJkpUIO0/bI9MhwmD70S5aTWbXGBwxHrelT+XM1k6dM0pk+SwNkpTRN7Pg==",
-      "dev": true,
+      "version": "8.5.10",
+      "resolved": "https://registry.npmjs.org/postcss/-/postcss-8.5.10.tgz",
+      "integrity": "sha512-pMMHxBOZKFU6HgAZ4eyGnwXF/EvPGGqUr0MnZ5+99485wwW41kW91A4LOGxSHhgugZmSChL5AlElNdwlNgcnLQ==",
       "funding": [
         {
           "type": "opencollective",

--- a/package.json
+++ b/package.json
@@ -31,6 +31,9 @@
     "node": ">=22.12.0"
   },
   "packageManager": "npm@10.9.0",
+  "overrides": {
+    "postcss": "8.5.10"
+  },
   "scripts": {
     "dev": "next dev --turbopack",
     "build": "next build",


### PR DESCRIPTION
## Summary

- force all PostCSS consumers, including Next.js, onto patched `postcss@8.5.10`
- remove the vulnerable nested `postcss@8.4.31` copy from the lockfile
- resolve Dependabot alert #98 / GHSA-qx2v-qp2m-jg93 (CVE-2026-41305)

## Why

Next.js 15.5.19 pins a vulnerable PostCSS release. `npm audit fix --force` proposes a breaking downgrade to Next.js 9, so an npm override is the smallest safe fix until Next.js ships a stable patched dependency.

## Validation

- `npm run build`
- `npx tsc --noEmit`
- `npm ls postcss` → all consumers use `8.5.10`
- `npm audit` no longer reports PostCSS / GHSA-qx2v-qp2m-jg93