### PR TITLE
Fix React Doctor findings

### DIFF
--- a/src/app/components/Footer.tsx
+++ b/src/app/components/Footer.tsx
@@ -1,6 +1,6 @@
 "use client";
 
-import React from "react";
+import React, { useSyncExternalStore } from "react";
 import Link from "next/link";
 import { siGithub } from "simple-icons";
 import Logo from "@/app/components/Logo";
@@ -18,7 +18,17 @@ function BrandIcon({ className, path }: BrandIconProps) {
   );
 }
 
+const subscribeToCurrentYear = () => () => {};
+const getCurrentYear = () => new Date().getFullYear();
+const getServerYear = () => null;
+
 export default function Footer() {
+  const currentYear = useSyncExternalStore(
+    subscribeToCurrentYear,
+    getCurrentYear,
+    getServerYear
+  );
+
   return (
     <footer className="w-full border-t border-slate-100 bg-slate-50/50">
       <div className="mx-auto max-w-6xl px-6 py-12">
@@ -53,7 +63,7 @@ export default function Footer() {
 
         <div className="mt-8 flex flex-col items-center justify-between gap-4 border-t border-slate-200 pt-8 sm:flex-row">
           <p className="text-xs text-slate-400">
-            &copy; {new Date().getFullYear()} UDID Tools. All rights reserved.
+            &copy; {currentYear} UDID Tools. All rights reserved.
           </p>
           <div className="flex items-center gap-6">
             <Link

--- a/src/app/components/MotionWrapper.tsx
+++ b/src/app/components/MotionWrapper.tsx
@@ -8,22 +8,20 @@ type MotionElement = "div" | "h1" | "h2" | "p";
 type MotionWrapperProps = {
   type?: MotionElement;
   children?: React.ReactNode;
+  ref?: React.Ref<unknown>;
   [key: string]: unknown;
 };
 
-const MotionWrapper = React.forwardRef<unknown, MotionWrapperProps>(
-  ({ type, children, ...props }, ref) => {
-    const Component = (
-      type === "h1" ? motion.h1 : type === "h2" ? motion.h2 : type === "p" ? motion.p : motion.div
-    ) as React.ElementType;
-    return (
-      <Component ref={ref} {...props}>
-        {children}
-      </Component>
-    );
-  }
-);
+function MotionWrapper({ type, children, ref, ...props }: MotionWrapperProps) {
+  const Component = (
+    type === "h1" ? motion.h1 : type === "h2" ? motion.h2 : type === "p" ? motion.p : motion.div
+  ) as React.ElementType;
 
-MotionWrapper.displayName = "MotionWrapper";
+  return (
+    <Component ref={ref} {...props}>
+      {children}
+    </Component>
+  );
+}
 
 export default MotionWrapper;

--- a/src/app/components/legal/LegalPage.tsx
+++ b/src/app/components/legal/LegalPage.tsx
@@ -19,7 +19,11 @@ type LegalPageProps = {
   sections: LegalSection[];
 };
 
-function renderTextWithLinks(text: string) {
+type TextWithLinksProps = {
+  text: string;
+};
+
+function TextWithLinks({ text }: TextWithLinksProps) {
   const parts = text.split(
     /(https?:\/\/[^\s.]+(?:\.[^\s.]+)*|[A-Z0-9._%+-]+@[A-Z0-9.-]+\.[A-Z]{2,})/gi
   );
@@ -95,7 +99,7 @@ export default function LegalPage({
                 <div className="space-y-4">
                   {section.paragraphs?.map((paragraph) => (
                     <p key={paragraph} className="leading-7 text-slate-600">
-                      {renderTextWithLinks(paragraph)}
+                      <TextWithLinks text={paragraph} />
                     </p>
                   ))}
                 </div>
@@ -103,7 +107,7 @@ export default function LegalPage({
                   <ul className="mt-4 list-disc space-y-2 pl-6 text-slate-600 marker:text-blue-500">
                     {section.items.map((item) => (
                       <li key={item} className="pl-1 leading-7">
-                        {renderTextWithLinks(item)}
+                        <TextWithLinks text={item} />
                       </li>
                     ))}
                   </ul>

--- a/src/app/components/ui/button-variants.ts
+++ b/src/app/components/ui/button-variants.ts
@@ -1,0 +1,30 @@
+import { cva } from "class-variance-authority";
+
+const buttonVariants = cva(
+  "inline-flex items-center justify-center gap-2 whitespace-nowrap rounded-md text-sm font-medium transition-colors focus-visible:outline-none focus-visible:ring-1 focus-visible:ring-ring disabled:pointer-events-none disabled:opacity-50 [&_svg]:pointer-events-none [&_svg]:size-4 [&_svg]:shrink-0",
+  {
+    variants: {
+      variant: {
+        default: "bg-primary text-primary-foreground shadow hover:bg-primary/90",
+        destructive: "bg-destructive text-destructive-foreground shadow-sm hover:bg-destructive/90",
+        outline:
+          "border border-input bg-background shadow-sm hover:bg-accent hover:text-accent-foreground",
+        secondary: "bg-secondary text-secondary-foreground shadow-sm hover:bg-secondary/80",
+        ghost: "hover:bg-accent hover:text-accent-foreground",
+        link: "text-primary underline-offset-4 hover:underline",
+      },
+      size: {
+        default: "h-9 px-4 py-2",
+        sm: "h-8 rounded-md px-3 text-xs",
+        lg: "h-10 rounded-md px-8",
+        icon: "h-9 w-9",
+      },
+    },
+    defaultVariants: {
+      variant: "default",
+      size: "default",
+    },
+  }
+);
+
+export { buttonVariants };

--- a/src/app/components/ui/button.tsx
+++ b/src/app/components/ui/button.tsx
@@ -38,14 +38,10 @@ type ButtonProps = React.ComponentProps<"button"> &
     asChild?: boolean;
   };
 
-const Button = React.forwardRef<HTMLButtonElement, ButtonProps>(
-  ({ className, variant, size, asChild = false, ...props }, ref) => {
-    const Comp = asChild ? Slot : "button";
-    return (
-      <Comp className={cn(buttonVariants({ variant, size, className }))} ref={ref} {...props} />
-    );
-  }
-);
-Button.displayName = "Button";
+function Button({ className, variant, size, asChild = false, ref, ...props }: ButtonProps) {
+  const Comp = asChild ? Slot : "button";
+
+  return <Comp className={cn(buttonVariants({ variant, size, className }))} ref={ref} {...props} />;
+}
 
 export { Button, buttonVariants };

--- a/src/app/components/ui/button.tsx
+++ b/src/app/components/ui/button.tsx
@@ -2,36 +2,10 @@
 
 import * as React from "react";
 import { Slot } from "@radix-ui/react-slot";
-import { cva, type VariantProps } from "class-variance-authority";
+import type { VariantProps } from "class-variance-authority";
 
+import { buttonVariants } from "@/app/components/ui/button-variants";
 import { cn } from "@/lib/utils";
-
-const buttonVariants = cva(
-  "inline-flex items-center justify-center gap-2 whitespace-nowrap rounded-md text-sm font-medium transition-colors focus-visible:outline-none focus-visible:ring-1 focus-visible:ring-ring disabled:pointer-events-none disabled:opacity-50 [&_svg]:pointer-events-none [&_svg]:size-4 [&_svg]:shrink-0",
-  {
-    variants: {
-      variant: {
-        default: "bg-primary text-primary-foreground shadow hover:bg-primary/90",
-        destructive: "bg-destructive text-destructive-foreground shadow-sm hover:bg-destructive/90",
-        outline:
-          "border border-input bg-background shadow-sm hover:bg-accent hover:text-accent-foreground",
-        secondary: "bg-secondary text-secondary-foreground shadow-sm hover:bg-secondary/80",
-        ghost: "hover:bg-accent hover:text-accent-foreground",
-        link: "text-primary underline-offset-4 hover:underline",
-      },
-      size: {
-        default: "h-9 px-4 py-2",
-        sm: "h-8 rounded-md px-3 text-xs",
-        lg: "h-10 rounded-md px-8",
-        icon: "h-9 w-9",
-      },
-    },
-    defaultVariants: {
-      variant: "default",
-      size: "default",
-    },
-  }
-);
 
 type ButtonProps = React.ComponentProps<"button"> &
   VariantProps<typeof buttonVariants> & {
@@ -44,4 +18,4 @@ function Button({ className, variant, size, asChild = false, ref, ...props }: Bu
   return <Comp className={cn(buttonVariants({ variant, size, className }))} ref={ref} {...props} />;
 }
 
-export { Button, buttonVariants };
+export { Button };


### PR DESCRIPTION
## Summary
- Fixed the top React Doctor issue groups around hydration-safe dates, React 19 ref handling, and render helpers used inside render.
- Split `buttonVariants` out of the `Button` component file so Fast Refresh can safely preserve component state.

## Validation
- `npm run lint`
- `npx tsc --noEmit`
- `npx react-doctor@latest --verbose --scope changed` → 100/100, no issues found
- Full `npx react-doctor@latest --verbose` confirms the fixed findings are gone; remaining issues are unrelated pre-existing follow-ups.